### PR TITLE
Add Optional Potion Ring Durability

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@ mc.version=1.12.2
 forge.version=14.23.5.2847
 mcp.version=stable_39
 
-crafttweaker.version=1.12-4.1.20.554
+crafttweaker.version=1.12-4.1.20.674
 jei.version=4.15.0.291
 baubles.project_id=227083
 baubles.file_id=2518667

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -206,7 +206,7 @@ public class ItemRing extends Item implements IBauble {
     }
 
     protected void updatePotionStatus(EntityLivingBase player, Potion potion, ItemStack stack, boolean unequipping) {
-        if (potion == null || player.world.isRemote || !(player instanceof EntityPlayer)) {
+        if (potion == null || player.getEntityWorld().isRemote || !(player instanceof EntityPlayer)) {
             return;
         }
 
@@ -236,19 +236,17 @@ public class ItemRing extends Item implements IBauble {
     }
 
     protected void updateDurabilityStatus(EntityLivingBase player, int durability, ItemStack stack) {
-        if (durability < 0 || player.world.isRemote || !(player instanceof EntityPlayer)) {
+        if (durability < 0 || player.getEntityWorld().isRemote || !(player instanceof EntityPlayer)) {
             return;
         }
 
-        if (!player.getEntityWorld().isRemote) {
-            if (durability - 1 >= 0) {
-                // reduce durability by 1 if there is durability left
-                getOrCreateNBTTag(stack).setInteger(TAG_DURABILITY, durability - 1);
-            } else {
-                // play the item breaking sound and then destroy the item
-                player.getEntityWorld().playSound(null, player.getPosition(), SoundEvents.ENTITY_ITEM_BREAK, SoundCategory.PLAYERS, 1.0F, 1.0F);
-                stack.setCount(0);
-            }
+        if (durability - 1 >= 0) {
+            // reduce durability by 1 if there is durability left
+            getOrCreateNBTTag(stack).setInteger(TAG_DURABILITY, durability - 1);
+        } else {
+            // play the item breaking sound and then destroy the item
+            player.getEntityWorld().playSound(null, player.getPosition(), SoundEvents.ENTITY_ITEM_BREAK, SoundCategory.PLAYERS, 1.0F, 1.0F);
+            stack.setCount(0);
         }
     }
 

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -252,11 +252,7 @@ public class ItemRing extends Item implements IBauble {
 
     @Override
     public boolean showDurabilityBar(@Nonnull ItemStack stack) {
-        if (stack.hasTagCompound()) {
-            //noinspection ConstantConditions
-            return stack.getTagCompound().hasKey(TAG_DURABILITY);
-        }
-        return super.showDurabilityBar(stack);
+        return isDamaged(stack);
     }
 
     @Override
@@ -286,9 +282,9 @@ public class ItemRing extends Item implements IBauble {
     public boolean isDamaged(@Nonnull ItemStack stack) {
         //noinspection ConstantConditions
         if (stack.hasTagCompound() && stack.getTagCompound().hasKey(TAG_DURABILITY)) {
-            return stack.getTagCompound().getInteger(TAG_DURABILITY) >= 0;
+            return getDamage(stack) > 0;
         }
-        return super.isDamaged(stack);
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Adds the ability for Potion Rings to have durability. Every time the effect duration is refreshed, durability is decreased by one, until the ring eventually breaks.

You can create a ring with durability by giving it two nbt tags in addition to the effect:
```zs
{effect: "minecraft:speed", durability: 200, maxDurability: 500}
```
This will create a ring with 200 out of 500 durability points. 

Utilizing this is **optional**. Rings that do not have durability related NBT will not have durability mechanics and will last forever. 